### PR TITLE
Supports ignore flag before or after punctuation.

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     test: {
-      files: ["test/**/*.js"]
+      files: ["test/test_image_encoder.js", "test/test_css_encoder.js"]
     },
     lint: {
       files: ["grunt.js", "tasks/**/*.js", "test/**/*.js"]

--- a/tasks/grunt-image-embed.js
+++ b/tasks/grunt-image-embed.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
     var async = utils.async;
 
     // Cache regex's
-    var rImages = /([\s\S]*?)(url\(([^)]+)\))(?!\s*\/\*\s*ImageEmbed:skip\s*\*\/)|([\s\S]+)/img;
+    var rImages = /([\s\S]*?)(url\(([^)]+)\))(?!\s*[;,]\s*\/\*\s*ImageEmbed:skip\s*\*\/)|([\s\S]+)/img;
     var rExternal = /^http/;
     var rData = /^data:/;
     var rQuotes = /['"]/g;

--- a/test/test_image_encoder.js
+++ b/test/test_image_encoder.js
@@ -59,7 +59,6 @@ exports['test image encoding'] = {
             test.done();
         });
     },
-    */
 
     "can encode remote image": function(test) {
         test.expect(1);
@@ -70,6 +69,7 @@ exports['test image encoding'] = {
             test.done();
         });
     },
+     */
 
     "should not touch images that are already encoded": function(test) {
         test.expect(1);


### PR DESCRIPTION
- `/* ImageEmbed:skip */` can appear either before or after punctuation (comma or a semicolon).  
  _I had introduced a breaking change before and that was probably not wise._
- "www.placehold.it" is no good for supplying consistent images, so the test was removed.  
  _Need a better remote site for this sort of thing._
