### PR TITLE
Cannot read property 'deleteAfterEncoding' of undefined

### DIFF
--- a/tasks/grunt-image-embed.js
+++ b/tasks/grunt-image-embed.js
@@ -75,6 +75,7 @@ module.exports = function(grunt) {
    * @param done Function to call once encoding has finished.
    */
   grunt.registerHelper("encode_stylesheet", function(srcFile, opts, done) {
+    opts = opts || {};
     // Shift args if no options object is specified
     if(utils.kindOf(opts) === "function") {
       done = opts;


### PR DESCRIPTION
I get an error like:

```
TypeError: Cannot read property 'deleteAfterEncoding' of undefined
    at Object.module.exports.grunt.registerHelper.done (/home/stuart/src/3akai-ux/node_modules/grunt-image-embed/tasks/grunt-image-embed.js:84:35)
    at Task.helper (/home/stuart/src/3akai-ux/node_modules/grunt/lib/util/task.js:119:19)
    at module.exports.grunt.registerHelper.done (/home/stuart/src/3akai-ux/node_modules/grunt-image-embed/tasks/grunt-image-embed.js:57:15)
    at async.parallel.results (/home/stuart/src/3akai-ux/node_modules/grunt/node_modules/async/lib/async.js:454:21)
    at _asyncMap (/home/stuart/src/3akai-ux/node_modules/grunt/node_modules/async/lib/async.js:185:13)
    at async.forEach (/home/stuart/src/3akai-ux/node_modules/grunt/node_modules/async/lib/async.js:86:13)
    at Array.forEach (native)
    at _forEach (/home/stuart/src/3akai-ux/node_modules/grunt/node_modules/async/lib/async.js:26:24)
    at async.forEach (/home/stuart/src/3akai-ux/node_modules/grunt/node_modules/async/lib/async.js:85:9)
    at _asyncMap (/home/stuart/src/3akai-ux/node_modules/grunt/node_modules/async/lib/async.js:184:9)
```

This patch makes sure the `opts` object is defined before trying to read its properties.
