### PR TITLE
Use baseDir also for relative paths

### DIFF
--- a/tasks/lib/encode.js
+++ b/tasks/lib/encode.js
@@ -96,7 +96,7 @@ exports.init = function(grunt) {
             // local file system.. fix up the path
             loc = img.charAt(0) === "/" ?
               (opts.baseDir || "") + loc :
-              path.join(path.dirname(srcFile), img);
+              path.join(path.dirname(srcFile),  (opts.baseDir || "") + img);
 
             // If that didn't work, try finding the image relative to
             // the current file instead.


### PR DESCRIPTION
I use the grunt-usemin task to concate the css files from html page. 
So now I have all my files in a single css file my dist folder, using your task I cant find the images as I can't set the root for my relative image paths.
This change fix the issue for me.

Btw. my image path starts with `../` maybe thats an issue as you only check for `/`.
