### PR TITLE
Fixed #19 and improved work with multiple files

### DIFF
--- a/tasks/grunt-image-embed.js
+++ b/tasks/grunt-image-embed.js
@@ -6,10 +6,13 @@
  * Licensed under the MIT license.
  */
 
+// External libs
+var path = require('path');
+
 // Internal libs
 var grunt_encode = require("./lib/encode");
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
   "use strict";
 
   // Grunt lib init
@@ -18,25 +21,56 @@ module.exports = function(grunt) {
   // Grunt utils
   var async = grunt.util.async;
 
-  grunt.registerMultiTask("imageEmbed", "Embed images as base64 data URIs inside your stylesheets", function() {
+  grunt.registerMultiTask("imageEmbed", "Embed images as base64 data URIs inside your stylesheets", function () {
     var opts = this.options();
     var done = this.async();
 
     // Process each src file
-    this.files.forEach(function(file) {
+    this.files.forEach(function (file) {
+      var cwd = file.cwd;
       var dest = file.dest;
-      var tasks;
+      var destIsFile = !!path.extname(dest);
 
-      tasks = file.src.map(function(srcFile) {
-        return function(callback) {
+      var src = file.src.filter(function(src) {
+        if (cwd) {
+          src = path.join(cwd, src);
+        }
+
+        if (grunt.file.isFile(src)) {
+          return true;
+        } else {
+          grunt.log.warn('Source file "' + src + '" not found.');
+          return false;
+        }
+      });
+
+      if (src.length > 1 && destIsFile) {
+        grunt.log.warn('Source file cannot be more than one when dest is a file.');
+      }
+
+
+      var tasks = file.src.map(function (srcFile) {
+        return function (callback) {
+          if (cwd) {
+            srcFile = path.join(cwd, srcFile);
+          }
           encode.stylesheet(srcFile, opts, callback);
         };
       });
 
       // Once all files have been processed write them out.
-      async.parallel(tasks, function(err, output) {
-        grunt.file.write(dest, output);
-        grunt.log.writeln('File "' + dest + '" created.');
+      async.parallel(tasks, function (err, output) {
+        if (destIsFile) {
+          grunt.file.write(dest, content);
+          grunt.log.writeln('File "' + dest + '" created.');
+        } else {
+          output.forEach(function (content, index) {
+            var outputPath = path.join(dest, src[index]);
+            grunt.file.write(outputPath, content);
+            grunt.log.writeln('File "' + outputPath + '" created.');
+          });
+        }
+
         done();
       });
     });

--- a/tasks/grunt-image-embed.js
+++ b/tasks/grunt-image-embed.js
@@ -8,6 +8,7 @@
 
 // External libs
 var path = require('path');
+var fs = require("fs");
 
 // Internal libs
 var grunt_encode = require("./lib/encode");
@@ -70,6 +71,13 @@ module.exports = function (grunt) {
             grunt.log.writeln('File "' + outputPath + '" created.');
           });
         }
+
+        encode.filesToDelete.forEach(function (file) {
+          if (grunt.file.isFile(file)) {
+            grunt.log.writeln("deleting " + file);
+            fs.unlinkSync(file);
+          }
+        });
 
         done();
       });

--- a/tasks/lib/encode.js
+++ b/tasks/lib/encode.js
@@ -36,6 +36,8 @@ exports.init = function(grunt) {
   var _ = utils._;
   var async = utils.async;
 
+  // storage for files what must be deleted after processing
+  exports.filesToDelete = [];
   /**
    * Takes a CSS file as input, goes through it line by line, and base64
    * encodes any images it finds.
@@ -115,8 +117,7 @@ exports.init = function(grunt) {
               }
 
               if(deleteAfterEncoding && is_local_file) {
-                grunt.log.writeln("deleting " + loc);
-                fs.unlinkSync(loc);
+                exports.filesToDelete.push(loc);
               }
             } else {
               result += group[2];


### PR DESCRIPTION
Now we can use one task for multiple css file, for example:

```
dist: {
  cwd: 'app/assets/styles',
  src: [ "*.css" ],
  dest: "dist/assets/styles/",
}
```

All css files from `app/assets/styles` will processed and saved to `dist/assets/styles` directory.

PS. Sorry for my bad english, I'm non-native speaker, feel free to correct me :)
