### PR TITLE
call done() exactly once

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ grunt.initConfig({
       src: [ "css/styles.css" ],
       dest: "css/output.css",
       options: {
-        deleteAfterEncoding : false
+        deleteAfterEncoding : false,
+        preEncodeCallback: function (filename) { return true; }
       }
     }
   }
@@ -56,6 +57,7 @@ ImageEmbed can be customized by specifying the following options:
 * `maxImageSize`: The maximum size of the base64 string in bytes. This defaults to `32768`, or IE8's limit. Set this to `0` to remove the limit and allow any size string.
 * `baseDir`: If you have absolute image paths in your stylesheet, the path specified in this option will be used as the base directory.
 * `deleteAfterEncoding`: Set this to true to delete images after they've been encoded. You'll want to do this in a staging area, and not in your source directories.  Be careful.
+* `preEncodeCallback`: function that takes full path to the image to be encoded and returns either `true` (proceeed with default encoding), `false` (abort the encoding, fail with error) or String, which will be used as the result of the encoding
 
 ### Skipping Images
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "grunt-image-embed",
   "description" : "Grunt task for embedding images as base64 data URIs inside your stylesheets.",
-  "version" : "0.3.1",
+  "version" : "0.3.2",
   "homepage" : "",
   "author" : {
     "name" : "Eric Hynds",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "grunt-image-embed",
   "description" : "Grunt task for embedding images as base64 data URIs inside your stylesheets.",
-  "version" : "0.3.2",
+  "version" : "0.3.3",
   "homepage" : "",
   "author" : {
     "name" : "Eric Hynds",

--- a/tasks/grunt-image-embed.js
+++ b/tasks/grunt-image-embed.js
@@ -21,6 +21,8 @@ module.exports = function(grunt) {
   grunt.registerMultiTask("imageEmbed", "Embed images as base64 data URIs inside your stylesheets", function() {
     var opts = this.options();
     var done = this.async();
+    var filesCount = this.files.length;
+    var doneCount = 0;
 
     // Process each src file
     this.files.forEach(function(file) {
@@ -37,7 +39,10 @@ module.exports = function(grunt) {
       async.parallel(tasks, function(err, output) {
         grunt.file.write(dest, output);
         grunt.log.writeln('File "' + dest + '" created.');
-        done();
+        // call done() exactly once, after all files are processed
+        if (++doneCount >= filesCount) {
+            done();
+        }
       });
     });
   });


### PR DESCRIPTION
fix for grunt.async().done() that was called multiple times
(for each source file), which broke following grunt async tasks.
