### PR TITLE
Fixes for record to 'dest' file when 'src' is multiple.

### DIFF
--- a/tasks/grunt-image-embed.js
+++ b/tasks/grunt-image-embed.js
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
 
       // Once all files have been processed write them out.
       grunt.util.async.parallel(tasks, function(err, output) {
-        grunt.file.write(dest, output);
+        grunt.file.write(dest, output.join('\n'));
         grunt.log.writeln('File "' + dest + '" created.');
 
         // call done() exactly once, after all files are processed


### PR DESCRIPTION
Small fix: output for 'dest' file. Now, without commas between code of multiple *.css files.
