### PR TITLE
Process file only if it is included AND not excluded

### DIFF
--- a/tasks/lib/encode.js
+++ b/tasks/lib/encode.js
@@ -78,7 +78,7 @@ module.exports.stylesheet = function(srcFile, opts, done) {
     //    group[4] will hold the entire string
 
     // Will skip processing if file is not included or is excluded
-    var process = group[3] && (group[3].match(rInclude) !== null || group[3].match(rExclude) === null);
+    var process = group[3] && (group[3].match(rInclude) !== null && group[3].match(rExclude) === null);
 
     if(group[4] == null && process) {
       result += group[1];


### PR DESCRIPTION
When `regexExclude` is passed, it won't stop file from processing, if it already matched `regexInclude`. Especially when `regexInclude` has default value, no files will be skipped, as they all match `regexInclude`.
