### PR TITLE
Reapply fix for multiple URLs

### DIFF
--- a/tasks/lib/encode.js
+++ b/tasks/lib/encode.js
@@ -15,7 +15,7 @@ var fetch = require('./fetch');
 var _ = grunt.util._;
 
 // Cache regex's
-var rImages = /([\s\S]*?)(url\(([^)]+)\))(?!\s*[;,]?\s*\/\*\s*ImageEmbed:skip\s*\*\/)|([\s\S]+)/img;
+var rImages = /([\s\S]*?)(url\(([^)]+)\))(?![^;]*;\s*\/\*\s*ImageEmbed:skip\s*\*\/)|([\s\S]+)/img;
 var rExternal = /^http/;
 var rSchemeless = /^\/\//;
 var rData = /^data:/;


### PR DESCRIPTION
This reapplies the fix from https://github.com/ehynds/grunt-image-embed/commit/7c09b8635db12d2a066886e3f8ae5524a3be6e16